### PR TITLE
Add missing labels for cronjobs

### DIFF
--- a/charts/c100-application/templates/cronjob.yaml
+++ b/charts/c100-application/templates/cronjob.yaml
@@ -6,12 +6,13 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ template "hmcts.releasename.v2" . }}-cronjob
-  app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-cronjob
-  helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-  app.kubernetes.io/managed-by: {{ .Release.Service }}
-  app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-cronjob
-  aadpodidbinding: {{ .Values.base.aadIdentityName }}
+  labels:
+    name: {{ template "hmcts.releasename.v2" . }}-cronjob
+    app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-cronjob
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-cronjob
+    aadpodidbinding: {{ .Values.base.aadIdentityName }}
 {{- include "hmcts.annotations.v2" . | indent 2 }}
 spec:
   schedule: "*/1 * * * *" # for testing

--- a/charts/c100-application/templates/cronjob.yaml
+++ b/charts/c100-application/templates/cronjob.yaml
@@ -6,8 +6,8 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  name: {{ template "hmcts.releasename.v2" . }}-cronjob
   labels:
-    name: {{ template "hmcts.releasename.v2" . }}-cronjob
     app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-cronjob
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/c100-application/templates/cronjob.yaml
+++ b/charts/c100-application/templates/cronjob.yaml
@@ -7,7 +7,11 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "hmcts.releasename.v2" . }}-cronjob
-{{- include "hmcts.labels.v2" . | indent 2 -}}
+  app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-cronjob
+  helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  app.kubernetes.io/managed-by: {{ .Release.Service }}
+  app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-cronjob
+  aadpodidbinding: {{ .Values.base.aadIdentityName }}
 {{- include "hmcts.annotations.v2" . | indent 2 }}
 spec:
   schedule: "*/1 * * * *" # for testing
@@ -22,7 +26,11 @@ spec:
       template:
         metadata:
           labels:
-            tier: worker
+            app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-cronjob
+            helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+            app.kubernetes.io/managed-by: {{ .Release.Service }}
+            app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-cronjob
+            aadpodidbinding: {{ .Values.base.aadIdentityName }}
         spec:
           restartPolicy: Never
           {{- include "hmcts.interpodantiaffinity.v2" $base | indent 10 }}

--- a/charts/c100-application/templates/cronjob_payments.yaml
+++ b/charts/c100-application/templates/cronjob_payments.yaml
@@ -7,7 +7,11 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "hmcts.releasename.v2" . }}-paymts
-{{- include "hmcts.labels.v2" . | indent 2 -}}
+  app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-paymts
+  helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  app.kubernetes.io/managed-by: {{ .Release.Service }}
+  app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-paymts
+  aadpodidbinding: {{ .Values.base.aadIdentityName }}
 {{- include "hmcts.annotations.v2" . | indent 2 }}
 spec:
   schedule: "*/1 * * * *" # for testing
@@ -22,7 +26,12 @@ spec:
       template:
         metadata:
           labels:
-            tier: worker
+            name: {{ template "hmcts.releasename.v2" . }}-paymts
+            app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-paymts
+            helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+            app.kubernetes.io/managed-by: {{ .Release.Service }}
+            app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-paymts
+            aadpodidbinding: {{ .Values.base.aadIdentityName }}
         spec:
           restartPolicy: OnFailure
           {{- include "hmcts.interpodantiaffinity.v2" $base | indent 10 }}

--- a/charts/c100-application/templates/cronjob_payments.yaml
+++ b/charts/c100-application/templates/cronjob_payments.yaml
@@ -6,12 +6,13 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ template "hmcts.releasename.v2" . }}-paymts
-  app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-paymts
-  helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-  app.kubernetes.io/managed-by: {{ .Release.Service }}
-  app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-paymts
-  aadpodidbinding: {{ .Values.base.aadIdentityName }}
+  labels:
+    name: {{ template "hmcts.releasename.v2" . }}-paymts
+    app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-paymts
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" $base }}-paymts
+    aadpodidbinding: {{ .Values.base.aadIdentityName }}
 {{- include "hmcts.annotations.v2" . | indent 2 }}
 spec:
   schedule: "*/1 * * * *" # for testing

--- a/charts/c100-application/templates/cronjob_payments.yaml
+++ b/charts/c100-application/templates/cronjob_payments.yaml
@@ -6,8 +6,8 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  name: {{ template "hmcts.releasename.v2" . }}-paymts
   labels:
-    name: {{ template "hmcts.releasename.v2" . }}-paymts
     app.kubernetes.io/name: {{ template "hmcts.releasename.v2" $base }}-paymts
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
As far as I can tell the right mounts are present but I assume old pod definitions are being run due to errors.

This will allow the identity to be assigned